### PR TITLE
Fix deprecation warnings

### DIFF
--- a/constants.asm
+++ b/constants.asm
@@ -1,224 +1,224 @@
 ; Initializing
-SP_INIT  EQU $cfff ; Initial location of Stack Pointer
+DEF SP_INIT  EQU $cfff ; Initial location of Stack Pointer
 
 ; Screen constants
-SCREEN_HEIGHT EQU 144  ; Visible Pixels before VBlank ($90)
-SCREEN_WIDTH  EQU 160  ; Visible Pixels before HBlank ($A0)
-LCDC_ON       EQU $80  ; Turn LCDC on
-LCDC_STANDARD EQU $d3  ; LCDC, BG, Sprites on, Window Tile Map starts at $9c00, 
+DEF SCREEN_HEIGHT EQU 144  ; Visible Pixels before VBlank ($90)
+DEF SCREEN_WIDTH  EQU 160  ; Visible Pixels before HBlank ($A0)
+DEF LCDC_ON       EQU $80  ; Turn LCDC on
+DEF LCDC_STANDARD EQU $d3  ; LCDC, BG, Sprites on, Window Tile Map starts at $9c00,
                        ; BG & Window Tile Data starts at $8000,
                        ; BG Tile Map Display starts at $9800,
                        ; OBJ (Sprite) Size is set to 8x8 pixels
 
 ; Joypad constants (internal meaning: directional buttons in the upper nibble, numbers equal the bit set)
-BTN_RIGHT  EQU 4  ; Directional Right
-BTN_LEFT   EQU 5  ; Directional Left
-BTN_UP     EQU 6  ; Directional Up
-BTN_DOWN   EQU 7  ; Directional Down
-BTN_A      EQU 0  ; Button A
-BTN_B      EQU 1  ; Button B
-BTN_SELECT EQU 2  ; Button Select
-BTN_START  EQU 3  ; Button Start
+DEF BTN_RIGHT  EQU 4  ; Directional Right
+DEF BTN_LEFT   EQU 5  ; Directional Left
+DEF BTN_UP     EQU 6  ; Directional Up
+DEF BTN_DOWN   EQU 7  ; Directional Down
+DEF BTN_A      EQU 0  ; Button A
+DEF BTN_B      EQU 1  ; Button B
+DEF BTN_SELECT EQU 2  ; Button Select
+DEF BTN_START  EQU 3  ; Button Start
 
 
 
 
 ; Sound constants
-SOUND_ON   EQU $80
-USE_ALL_CHANNELS   EQU $FF ; Set all audio channels to both output terminals (stereo)
-MASTER_VOLUME_MAX  EQU $77 ; Set both output terminals to highest volume
-ENVELOPE_NO_SOUND  EQU $08 ; Sets an envelope to no sound and direction to "increase"
+DEF SOUND_ON   EQU $80
+DEF USE_ALL_CHANNELS   EQU $FF ; Set all audio channels to both output terminals (stereo)
+DEF MASTER_VOLUME_MAX  EQU $77 ; Set both output terminals to highest volume
+DEF ENVELOPE_NO_SOUND  EQU $08 ; Sets an envelope to no sound and direction to "increase"
 
 
 ; RAM constants
 ; c000-c09f is the OAM data source
 
-rSCORE1           EQU $c0a0 ; score, smallest digits, highest value = 99
-rSCORE2           EQU $c0a1 ; score, middle digits, highest value = 99 (= 9900)
-rSCORE3           EQU $c0a2 ; score, highest digits, highest value = 99 (= 990000)
-rLINE_CLEAR_START EQU $c0a3 ; $ca after clearing 1-3 line(s), $c9 after clearing 4 lines
+DEF rSCORE1           EQU $c0a0 ; score, smallest digits, highest value = 99
+DEF rSCORE2           EQU $c0a1 ; score, middle digits, highest value = 99 (= 9900)
+DEF rSCORE3           EQU $c0a2 ; score, highest digits, highest value = 99 (= 990000)
+DEF rLINE_CLEAR_START EQU $c0a3 ; $ca after clearing 1-3 line(s), $c9 after clearing 4 lines
 
-rUNKNOWN3   EQU $c0a4 ; ..
+DEF rUNKNOWN3   EQU $c0a4 ; ..
 
-rHIDE_NEXT_BLOCK            EQU $c0de ; 0 = normal, 1 = next block display hidden (toggled by select button. Keeps value even if hidden in pause menu.)
+DEF rHIDE_NEXT_BLOCK            EQU $c0de ; 0 = normal, 1 = next block display hidden (toggled by select button. Keeps value even if hidden in pause menu.)
 
-rBLOCK_VISIBILITY   EQU $c200 ; 80 = invisible, 0 = visible 
-rBLOCK_Y            EQU $c201 ; Y location of falling block
-rBLOCK_X            EQU $c202 ; X location of falling block
-rBLOCK_TYPE         EQU $c203 ; Block type of falling block (see list below)
+DEF rBLOCK_VISIBILITY   EQU $c200 ; 80 = invisible, 0 = visible
+DEF rBLOCK_Y            EQU $c201 ; Y location of falling block
+DEF rBLOCK_X            EQU $c202 ; X location of falling block
+DEF rBLOCK_TYPE         EQU $c203 ; Block type of falling block (see list below)
 
-rNEXT_BLOCK_VISIBILITY   EQU $c210 ; 80 = invisible, 0 = visible 
-rNEXT_BLOCK_Y            EQU $c211 ; Y location of next block (always $80)
-rNEXT_BLOCK_X            EQU $c212 ; X location of next block (always $8f)
-rNEXT_BLOCK_TYPE         EQU $c213 ; Block type of next block (see list below, always the first unrotated variant)
+DEF rNEXT_BLOCK_VISIBILITY   EQU $c210 ; 80 = invisible, 0 = visible
+DEF rNEXT_BLOCK_Y            EQU $c211 ; Y location of next block (always $80)
+DEF rNEXT_BLOCK_X            EQU $c212 ; X location of next block (always $8f)
+DEF rNEXT_BLOCK_TYPE         EQU $c213 ; Block type of next block (see list below, always the first unrotated variant)
 
 ; Block types: (higher numbers mean counter-clockwise rotation. A-Button decreases number -> clockwise rotation)
                               ; ###
-rL_SHAPE_0          EQU $00   ; #
-rL_SHAPE_1          EQU $01
-rL_SHAPE_2          EQU $02
-rL_SHAPE_3          EQU $03
+DEF rL_SHAPE_0          EQU $00   ; #
+DEF rL_SHAPE_1          EQU $01
+DEF rL_SHAPE_2          EQU $02
+DEF rL_SHAPE_3          EQU $03
                               ; ###
-rREVERSE_L_SHAPE_0  EQU $04   ;   #
-rREVERSE_L_SHAPE_1  EQU $05
-rREVERSE_L_SHAPE_2  EQU $06
-rREVERSE_L_SHAPE_3  EQU $07
+DEF rREVERSE_L_SHAPE_0  EQU $04   ;   #
+DEF rREVERSE_L_SHAPE_1  EQU $05
+DEF rREVERSE_L_SHAPE_2  EQU $06
+DEF rREVERSE_L_SHAPE_3  EQU $07
 
-rI_SHAPE_0          EQU $08   ; ####
-rI_SHAPE_1          EQU $09
-rI_SHAPE_2          EQU $0a
-rI_SHAPE_3          EQU $0b
+DEF rI_SHAPE_0          EQU $08   ; ####
+DEF rI_SHAPE_1          EQU $09
+DEF rI_SHAPE_2          EQU $0a
+DEF rI_SHAPE_3          EQU $0b
                               ; ##
-rSQUARE_SHAPE_0     EQU $0c   ; ##
-rSQUARE_SHAPE_1     EQU $0d   ; (Yes the square can be rotated!)
-rSQUARE_SHAPE_2     EQU $0e
-rSQUARE_SHAPE_3     EQU $0f
+DEF rSQUARE_SHAPE_0     EQU $0c   ; ##
+DEF rSQUARE_SHAPE_1     EQU $0d   ; (Yes the square can be rotated!)
+DEF rSQUARE_SHAPE_2     EQU $0e
+DEF rSQUARE_SHAPE_3     EQU $0f
                               ; ##
-rZ_SHAPE_0          EQU $10   ;  ##
-rZ_SHAPE_1          EQU $11
-rZ_SHAPE_2          EQU $12
-rZ_SHAPE_3          EQU $13
+DEF rZ_SHAPE_0          EQU $10   ;  ##
+DEF rZ_SHAPE_1          EQU $11
+DEF rZ_SHAPE_2          EQU $12
+DEF rZ_SHAPE_3          EQU $13
                               ;  ##
-rS_SHAPE_0          EQU $14   ; ##
-rS_SHAPE_1          EQU $15
-rS_SHAPE_2          EQU $16
-rS_SHAPE_3          EQU $17
+DEF rS_SHAPE_0          EQU $14   ; ##
+DEF rS_SHAPE_1          EQU $15
+DEF rS_SHAPE_2          EQU $16
+DEF rS_SHAPE_3          EQU $17
                               ; ###
-rT_SHAPE_0          EQU $18   ;  #
-rT_SHAPE_1          EQU $19
-rT_SHAPE_2          EQU $1a
-rT_SHAPE_3          EQU $1b
+DEF rT_SHAPE_0          EQU $18   ;  #
+DEF rT_SHAPE_1          EQU $19
+DEF rT_SHAPE_2          EQU $1a
+DEF rT_SHAPE_3          EQU $1b
 
 
-rHIDE_NEXT_BLOCK_DISPLAY    EQU $c210 ; 0 = normal, $80 = next block display hidden - DISPLAY (always $80 in pause menu)
+DEF rHIDE_NEXT_BLOCK_DISPLAY    EQU $c210 ; 0 = normal, $80 = next block display hidden - DISPLAY (always $80 in pause menu)
 
-rPAUSED          EQU $df7f ; 00 = normal / paused, 01 = pause pressed, 02 = unpause pressed
-rPAUSE_CHIME     EQU $df7e ; 00 = normal, 11 = final value in pause menu after countdown, 30 = initial value when pause pressed 
+DEF rPAUSED          EQU $df7f ; 00 = normal / paused, 01 = pause pressed, 02 = unpause pressed
+DEF rPAUSE_CHIME     EQU $df7e ; 00 = normal, 11 = final value in pause menu after countdown, 30 = initial value when pause pressed
 
-rSOUND1     EQU $dfe1 ; (Set whenever a new sound is about to be played)
-rSOUND2     EQU $dfe9 ; ?
-rSOUND3     EQU $dff1 ; ?
-rSOUND4     EQU $dff9 ; ?
-rSOUND5     EQU $df9f ; ?
-rSOUND6     EQU $dfaf ; ?
-rSOUND7     EQU $dfbf ; ?
-rSOUND8     EQU $dfcf ; ?
-rSOUND9     EQU $df78 ; ?
+DEF rSOUND1     EQU $dfe1 ; (Set whenever a new sound is about to be played)
+DEF rSOUND2     EQU $dfe9 ; ?
+DEF rSOUND3     EQU $dff1 ; ?
+DEF rSOUND4     EQU $dff9 ; ?
+DEF rSOUND5     EQU $df9f ; ?
+DEF rSOUND6     EQU $dfaf ; ?
+DEF rSOUND7     EQU $dfbf ; ?
+DEF rSOUND8     EQU $dfcf ; ?
+DEF rSOUND9     EQU $df78 ; ?
 
 
 ; Hardware registers
-rMBC        EQU $2000 ; MBC Controller - Select ROM bank 0 (not needed in Tetris)
-rJOYP       EQU $ff00 ; Joypad (R/W)
-rSB         EQU $ff01 ; Serial transfer data (R/W)
-rSC         EQU $ff02 ; Serial Transfer Control (R/W)
-rSC_ON    EQU 7
-rSC_CGB   EQU 1
-rSC_CLOCK EQU 0
-rDIV        EQU $ff04 ; Divider Register (R/W)
-rTIMA       EQU $ff05 ; Timer counter (R/W)
-rTMA        EQU $ff06 ; Timer Modulo (R/W)
-rTAC        EQU $ff07 ; Timer Control (R/W)
-rTAC_ON        EQU 2
-rTAC_4096_HZ   EQU 0
-rTAC_262144_HZ EQU 1
-rTAC_65536_HZ  EQU 2
-rTAC_16384_HZ  EQU 3
-rIF         EQU $ff0f ; Interrupt Flag (R/W)
-rNR10       EQU $ff10 ; Channel 1 Sweep register (R/W)
-rNR11       EQU $ff11 ; Channel 1 Sound length/Wave pattern duty (R/W)
-rNR12       EQU $ff12 ; Channel 1 Volume Envelope (R/W)
-rNR13       EQU $ff13 ; Channel 1 Frequency lo (Write Only)
-rNR14       EQU $ff14 ; Channel 1 Frequency hi (R/W)
-rNR21       EQU $ff16 ; Channel 2 Sound Length/Wave Pattern Duty (R/W)
-rNR22       EQU $ff17 ; Channel 2 Volume Envelope (R/W)
-rNR23       EQU $ff18 ; Channel 2 Frequency lo data (W)
-rNR24       EQU $ff19 ; Channel 2 Frequency hi data (R/W)
-rNR30       EQU $ff1a ; Channel 3 Sound on/off (R/W)
-rNR31       EQU $ff1b ; Channel 3 Sound Length
-rNR32       EQU $ff1c ; Channel 3 Select output level (R/W)
-rNR33       EQU $ff1d ; Channel 3 Frequency's lower data (W)
-rNR34       EQU $ff1e ; Channel 3 Frequency's higher data (R/W)
-rNR41       EQU $ff20 ; Channel 4 Sound Length (R/W)
-rNR42       EQU $ff21 ; Channel 4 Volume Envelope (R/W)
-rNR43       EQU $ff22 ; Channel 4 Polynomial Counter (R/W)
-rNR44       EQU $ff23 ; Channel 4 Counter/consecutive; Initial (R/W)
-rNR50       EQU $ff24 ; Channel control / ON-OFF / Volume (R/W)
-rNR51       EQU $ff25 ; Selection of Sound output terminal (R/W)
-rNR52       EQU $ff26 ; Sound on/off
-rLCDC       EQU $ff40 ; LCD Control (R/W)
+DEF rMBC        EQU $2000 ; MBC Controller - Select ROM bank 0 (not needed in Tetris)
+DEF rJOYP       EQU $ff00 ; Joypad (R/W)
+DEF rSB         EQU $ff01 ; Serial transfer data (R/W)
+DEF rSC         EQU $ff02 ; Serial Transfer Control (R/W)
+DEF rSC_ON    EQU 7
+DEF rSC_CGB   EQU 1
+DEF rSC_CLOCK EQU 0
+DEF rDIV        EQU $ff04 ; Divider Register (R/W)
+DEF rTIMA       EQU $ff05 ; Timer counter (R/W)
+DEF rTMA        EQU $ff06 ; Timer Modulo (R/W)
+DEF rTAC        EQU $ff07 ; Timer Control (R/W)
+DEF rTAC_ON        EQU 2
+DEF rTAC_4096_HZ   EQU 0
+DEF rTAC_262144_HZ EQU 1
+DEF rTAC_65536_HZ  EQU 2
+DEF rTAC_16384_HZ  EQU 3
+DEF rIF         EQU $ff0f ; Interrupt Flag (R/W)
+DEF rNR10       EQU $ff10 ; Channel 1 Sweep register (R/W)
+DEF rNR11       EQU $ff11 ; Channel 1 Sound length/Wave pattern duty (R/W)
+DEF rNR12       EQU $ff12 ; Channel 1 Volume Envelope (R/W)
+DEF rNR13       EQU $ff13 ; Channel 1 Frequency lo (Write Only)
+DEF rNR14       EQU $ff14 ; Channel 1 Frequency hi (R/W)
+DEF rNR21       EQU $ff16 ; Channel 2 Sound Length/Wave Pattern Duty (R/W)
+DEF rNR22       EQU $ff17 ; Channel 2 Volume Envelope (R/W)
+DEF rNR23       EQU $ff18 ; Channel 2 Frequency lo data (W)
+DEF rNR24       EQU $ff19 ; Channel 2 Frequency hi data (R/W)
+DEF rNR30       EQU $ff1a ; Channel 3 Sound on/off (R/W)
+DEF rNR31       EQU $ff1b ; Channel 3 Sound Length
+DEF rNR32       EQU $ff1c ; Channel 3 Select output level (R/W)
+DEF rNR33       EQU $ff1d ; Channel 3 Frequency's lower data (W)
+DEF rNR34       EQU $ff1e ; Channel 3 Frequency's higher data (R/W)
+DEF rNR41       EQU $ff20 ; Channel 4 Sound Length (R/W)
+DEF rNR42       EQU $ff21 ; Channel 4 Volume Envelope (R/W)
+DEF rNR43       EQU $ff22 ; Channel 4 Polynomial Counter (R/W)
+DEF rNR44       EQU $ff23 ; Channel 4 Counter/consecutive; Initial (R/W)
+DEF rNR50       EQU $ff24 ; Channel control / ON-OFF / Volume (R/W)
+DEF rNR51       EQU $ff25 ; Selection of Sound output terminal (R/W)
+DEF rNR52       EQU $ff26 ; Sound on/off
+DEF rLCDC       EQU $ff40 ; LCD Control (R/W)
 
-rLCDC_STAT  EQU $ff41 ; LCDC Status (R/W)
-rSCY        EQU $ff42 ; Scroll Y (R/W)
-rSCX        EQU $ff43 ; Scroll X (R/W)
-rLY         EQU $ff44 ; LCDC Y-Coordinate (R)
-rLYC        EQU $ff45 ; LY Compare (R/W)
-rDMA        EQU $ff46 ; DMA Transfer and Start Address (W)
-rBGP        EQU $ff47 ; BG Palette Data (R/W)
-rOBP0       EQU $ff48 ; Object Palette 0 Data (R/W)
-rOBP1       EQU $ff49 ; Object Palette 1 Data (R/W)
-rWY         EQU $ff4a ; Window Y Position (R/W)
-rWX         EQU $ff4b ; Window X Position minus 7 (R/W)
-rIE         EQU $ffff ; Interrupt Enable (R/W)
+DEF rLCDC_STAT  EQU $ff41 ; LCDC Status (R/W)
+DEF rSCY        EQU $ff42 ; Scroll Y (R/W)
+DEF rSCX        EQU $ff43 ; Scroll X (R/W)
+DEF rLY         EQU $ff44 ; LCDC Y-Coordinate (R)
+DEF rLYC        EQU $ff45 ; LY Compare (R/W)
+DEF rDMA        EQU $ff46 ; DMA Transfer and Start Address (W)
+DEF rBGP        EQU $ff47 ; BG Palette Data (R/W)
+DEF rOBP0       EQU $ff48 ; Object Palette 0 Data (R/W)
+DEF rOBP1       EQU $ff49 ; Object Palette 1 Data (R/W)
+DEF rWY         EQU $ff4a ; Window Y Position (R/W)
+DEF rWX         EQU $ff4b ; Window X Position minus 7 (R/W)
+DEF rIE         EQU $ffff ; Interrupt Enable (R/W)
 
 
 ; HRAM variables
-rBUTTON_DOWN     EQU $ff80 ; buttons currently pressed (lower nibble = buttons, higher nibble = directional keys)
-rBUTTON_HIT      EQU $ff81 ; buttons pressed for the first time
-rVBLANK_DONE     EQU $ff85 ; 1 = VBlank interrupt executed; 0 = Not executed yet
+DEF rBUTTON_DOWN     EQU $ff80 ; buttons currently pressed (lower nibble = buttons, higher nibble = directional keys)
+DEF rBUTTON_HIT      EQU $ff81 ; buttons pressed for the first time
+DEF rVBLANK_DONE     EQU $ff85 ; 1 = VBlank interrupt executed; 0 = Not executed yet
 
-rOAM_TILE_NO      EQU $ff89 ; temporary storage for OAM data of next transfer to $c000 - $c09f
-rOAM_ATTRIBUTE_NO EQU $ff8a ; "
-rUNKNOWN4         EQU $ff8b ; "
-rUNKNOWN5         EQU $ff8c ; 
+DEF rOAM_TILE_NO      EQU $ff89 ; temporary storage for OAM data of next transfer to $c000 - $c09f
+DEF rOAM_ATTRIBUTE_NO EQU $ff8a ; "
+DEF rUNKNOWN4         EQU $ff8b ; "
+DEF rUNKNOWN5         EQU $ff8c ;
 
-rOAM_TILE_ADDRESS_1  EQU $ff8d ; higher byte of target OAM storage address (in $c000 - $c09f) for transfer from temporary storage in HRAM
-rOAM_TILE_ADDRESS_2  EQU $ff8e ; lower byte " "
-rAMOUNT_SPRITES_TO_DRAW  EQU $ff8f ; draws X amount of sprites starting at $c200, incrementing by $10
+DEF rOAM_TILE_ADDRESS_1  EQU $ff8d ; higher byte of target OAM storage address (in $c000 - $c09f) for transfer from temporary storage in HRAM
+DEF rOAM_TILE_ADDRESS_2  EQU $ff8e ; lower byte " "
+DEF rAMOUNT_SPRITES_TO_DRAW  EQU $ff8f ; draws X amount of sprites starting at $c200, incrementing by $10
 
-rOAM_X_POS        EQU $ff92 ; temporary storage for OAM data of next transfer to $c000 - $c09f
-rOAM_Y_POS        EQU $ff93 ; "
-rUNKNOWN6         EQU $ff94 ; "
-rOAM_VISIBLE      EQU $ff95 ; " - $80 = invisible, $00 = visible
+DEF rOAM_X_POS        EQU $ff92 ; temporary storage for OAM data of next transfer to $c000 - $c09f
+DEF rOAM_Y_POS        EQU $ff93 ; "
+DEF rUNKNOWN6         EQU $ff94 ; "
+DEF rOAM_VISIBLE      EQU $ff95 ; " - $80 = invisible, $00 = visible
 
-rSPRITE_ORIGINAL_ADDRESS_1  EQU $ff96 ; higher byte of starting address of sprite info in $c200+
-rSPRITE_ORIGINAL_ADDRESS_2  EQU $ff97 ;  lower byte of starting address of sprite info in $c200+
+DEF rSPRITE_ORIGINAL_ADDRESS_1  EQU $ff96 ; higher byte of starting address of sprite info in $c200+
+DEF rSPRITE_ORIGINAL_ADDRESS_2  EQU $ff97 ;  lower byte of starting address of sprite info in $c200+
 
 
 
-rBLOCK_STATUS    EQU $ff98 ; runs from 1 to 3 when block hits ground; back to 0 before chime and line clear handling
+DEF rBLOCK_STATUS    EQU $ff98 ; runs from 1 to 3 when block hits ground; back to 0 before chime and line clear handling
 
-rGRAVITY         EQU $ff99 ; loops from $0a to $00, block falls down by one when transitioning from $0a to $09
+DEF rGRAVITY         EQU $ff99 ; loops from $0a to $00, block falls down by one when transitioning from $0a to $09
 
-rCLEAR_PROGRESS  EQU $ff9c ; runs from 1 to 7 during line clear animation
+DEF rCLEAR_PROGRESS  EQU $ff9c ; runs from 1 to 7 during line clear animation
 
-rLINES_CLEARED1  EQU $ff9e ; smallest digits of cleared line number in decimal, so highest value = 99 - or lines left in game type B
-rLINES_CLEARED2  EQU $ff9f ; highest digits, highest value also 99 (meaning 9900), making 9999 the highest line number possible.
+DEF rLINES_CLEARED1  EQU $ff9e ; smallest digits of cleared line number in decimal, so highest value = 99 - or lines left in game type B
+DEF rLINES_CLEARED2  EQU $ff9f ; highest digits, highest value also 99 (meaning 9900), making 9999 the highest line number possible.
 
-rIE_TEMP         EQU $ffa1 ; used for temporary storage of IE ($ffff)
+DEF rIE_TEMP         EQU $ffa1 ; used for temporary storage of IE ($ffff)
 
-rUNKNOWN1        EQU $ffa4 ; probably unused
-rCOUNTDOWN       EQU $ffa6 ; various uses - counts down one per VBlank (~59.7 times a second)
-rCOUNTDOWN2      EQU $ffa7 ; various uses - counts down one per VBlank  = 4 seconds per byte (256 values)
+DEF rUNKNOWN1        EQU $ffa4 ; probably unused
+DEF rCOUNTDOWN       EQU $ffa6 ; various uses - counts down one per VBlank (~59.7 times a second)
+DEF rCOUNTDOWN2      EQU $ffa7 ; various uses - counts down one per VBlank  = 4 seconds per byte (256 values)
 
-rPAUSE_MENU      EQU $ffab ; 0 = normal, 1 = in pause menu
+DEF rPAUSE_MENU      EQU $ffab ; 0 = normal, 1 = in pause menu
 
-rDEMO_STATUS     EQU $ffb0 ; $0 = normal, $03 - $0f = # of block in demo 1, $10 = back in main menu (between games) 
+DEF rDEMO_STATUS     EQU $ffb0 ; $0 = normal, $03 - $0f = # of block in demo 1, $10 = back in main menu (between games)
                            ;              $11 - $1c = # of block in demo 2, $1d = back in main menu (after demo 2, before demo 1 again)
 
 ; $ffb6 - $ffb7 = DMA transfer routine
 
-rGAME_TYPE       EQU $ffc0 ; $37 = Type A, $77 = Type B
-rMUSIC_TYPE      EQU $ffc1 ; $1c = Music A, $1d = Music B, $1e = Music C, $1f = Music off
-rLEVEL_A         EQU $ffc2 ; current level (type A)
-rLEVEL_B         EQU $ffc3 ; current level (type B)
-rINITIAL_HEIGHT  EQU $ffc4 ; height of blocks (Type B)
-rPLAYERS         EQU $ffc5 ; 0 = 1 player, 1 = 2 players 
-rMUSIC_COUNTDOWN EQU $ffc6 ; countdown for title screen music - until demo game starts playing (reduces by one whenever rCOUNTDOWN reaches 0)
-rUNKNOWN7        EQU $ffca ; related to hiscore entry
-rUNKNOWN8        EQU $ffcb ; ?Must be $29 to consider sending data in VBlank..
-rREQUEST_SERIAL_TRANSFER        EQU $ffce ; Request serial connection data transfer
-rSB_DATA         EQU $ffcf ; Holds the data to be sent via link cable
-rGAME_STATUS     EQU $ffe1 ; See table below:
+DEF rGAME_TYPE       EQU $ffc0 ; $37 = Type A, $77 = Type B
+DEF rMUSIC_TYPE      EQU $ffc1 ; $1c = Music A, $1d = Music B, $1e = Music C, $1f = Music off
+DEF rLEVEL_A         EQU $ffc2 ; current level (type A)
+DEF rLEVEL_B         EQU $ffc3 ; current level (type B)
+DEF rINITIAL_HEIGHT  EQU $ffc4 ; height of blocks (Type B)
+DEF rPLAYERS         EQU $ffc5 ; 0 = 1 player, 1 = 2 players
+DEF rMUSIC_COUNTDOWN EQU $ffc6 ; countdown for title screen music - until demo game starts playing (reduces by one whenever rCOUNTDOWN reaches 0)
+DEF rUNKNOWN7        EQU $ffca ; related to hiscore entry
+DEF rUNKNOWN8        EQU $ffcb ; ?Must be $29 to consider sending data in VBlank..
+DEF rREQUEST_SERIAL_TRANSFER        EQU $ffce ; Request serial connection data transfer
+DEF rSB_DATA         EQU $ffcf ; Holds the data to be sent via link cable
+DEF rGAME_STATUS     EQU $ffe1 ; See table below:
     ; $00 = in-game (both game types)
     ; $01 = shortly before game over screen
     ; $02 = !rocket launch 4
@@ -253,7 +253,7 @@ rGAME_STATUS     EQU $ffe1 ; See table below:
     ; $1F = !before 16
     ; $20 = !Luigi won screen
     ; $21 = !Luigi lost screen
-    ; $22 = !Shortly before congratulations animation 1 
+    ; $22 = !Shortly before congratulations animation 1
     ; $23 = !congratulations animation 1
     ; $24 = initial value copyright screen (very short)
     ; $25 = copyright screen during first countdown
@@ -274,73 +274,71 @@ rGAME_STATUS     EQU $ffe1 ; See table below:
     ; $34 = !shortly before rocket launch b
     ; $35 = copyright screen during second countdown
 
-                             
-rCOUNT_UP       EQU $ffe2 ; Counts from $00 to $FF (once per frame) - various uses 
-rROW_UPDATE     EQU $ffe3 ; current line to move down (after removing line(s))
-rDEMO_GAME      EQU $ffe4 ; 0 = normal game, 2 = first demo game (type A), 1 = second demo game (type B)
 
-rUNUSED             EQU $ffe9 ; set only in unused function. but tested everywhere. What a waste.
-rDEMO_ACTION_COUNTDOWN  EQU $ffea ; counts down the frames a button press (or none) is required acc. to storyboard (gravity works anyway)
-rDEMO_STORYBOARD_1  EQU $ffeb ; upper address of demo storyboard
-rDEMO_STORYBOARD_2  EQU $ffec ; lower address of demo storyboard
-rDEMO_BUTTON_HIT    EQU $ffed ; simulated button presses (see joypad constants above)
-rDEMO_ACTUAL_BUTTON EQU $ffee ; saves the actual button presses (after handling simulated ones), and then handles them (= Start btn to quit demo)
+DEF rCOUNT_UP       EQU $ffe2 ; Counts from $00 to $FF (once per frame) - various uses
+DEF rROW_UPDATE     EQU $ffe3 ; current line to move down (after removing line(s))
+DEF rDEMO_GAME      EQU $ffe4 ; 0 = normal game, 2 = first demo game (type A), 1 = second demo game (type B)
 
-rHARD_MODE      EQU $fff4 ; 0 = off, 88 = on
+DEF rUNUSED             EQU $ffe9 ; set only in unused function. but tested everywhere. What a waste.
+DEF rDEMO_ACTION_COUNTDOWN  EQU $ffea ; counts down the frames a button press (or none) is required acc. to storyboard (gravity works anyway)
+DEF rDEMO_STORYBOARD_1  EQU $ffeb ; upper address of demo storyboard
+DEF rDEMO_STORYBOARD_2  EQU $ffec ; lower address of demo storyboard
+DEF rDEMO_BUTTON_HIT    EQU $ffed ; simulated button presses (see joypad constants above)
+DEF rDEMO_ACTUAL_BUTTON EQU $ffee ; saves the actual button presses (after handling simulated ones), and then handles them (= Start btn to quit demo)
+
+DEF rHARD_MODE      EQU $fff4 ; 0 = off, 88 = on
 
 ; Variable value constants:
-GAME_TYPE_A     EQU   $37
-GAME_TYPE_B     EQU   $77
+DEF GAME_TYPE_A     EQU   $37
+DEF GAME_TYPE_B     EQU   $77
 
-MUSIC_TYPE_A    EQU   $1c
-MUSIC_TYPE_B    EQU   $1d
-MUSIC_TYPE_C    EQU   $1e
-MUSIC_TYPE_OFF  EQU   $1f
+DEF MUSIC_TYPE_A    EQU   $1c
+DEF MUSIC_TYPE_B    EQU   $1d
+DEF MUSIC_TYPE_C    EQU   $1e
+DEF MUSIC_TYPE_OFF  EQU   $1f
 
-MENU_IN_GAME          EQU   $00
-MENU_GAME_OVER_INIT   EQU   $01
-MENU_GAME_OVER        EQU   $04
-MENU_TYPE_B_WON       EQU   $05
-MENU_TITLE_INIT       EQU   $06
-MENU_TITLE            EQU   $07
-MENU_SELECT_TYPE_INIT EQU   $08
-MENU_IN_GAME_INIT     EQU   $0a
-MENU_SCORE_B          EQU   $0b
-MENU_LOST_ANIM        EQU   $0d
-MENU_SELECT_TYPE      EQU   $0e
-MENU_SELECT_MUSIC     EQU   $0f
-MENU_LEVEL_A_INIT     EQU   $10
-MENU_LEVEL_A          EQU   $11
-MENU_LEVEL_B_INIT     EQU   $12
-MENU_LEVEL_B          EQU   $13
-MENU_HIGH_B           EQU   $14
-MENU_HISCORE          EQU   $15
-MENU_COPYRIGHT_INIT   EQU   $24
-MENU_COPYRIGHT_1      EQU   $25
-MENU_COPYRIGHT_2      EQU   $35
-MENU_ROCKET_1_INIT    EQU   $26
-MENU_ROCKET_1A        EQU   $27
-MENU_ROCKET_1B        EQU   $28
-MENU_ROCKET_1C        EQU   $29
-MENU_ROCKET_1D        EQU   $02
-MENU_ROCKET_1E        EQU   $03
-MENU_ROCKET_1F        EQU   $2C
-MENU_ROCKET_1G        EQU   $2D
-MENU_ROCKET_2_INIT    EQU   $34
-MENU_ROCKET_2A        EQU   $2E
-MENU_ROCKET_2B        EQU   $2F
-MENU_ROCKET_2C        EQU   $30
-MENU_ROCKET_2D        EQU   $31
-MENU_ROCKET_2E        EQU   $32
-MENU_ROCKET_2F        EQU   $33
-MENU_CELEBRATE        EQU   $22
-MENU_VS_INIT          EQU   $16
-MENU_VS_MODE          EQU   $17
-MENU_VS_GAME_INIT     EQU   $18
-MENU_VS_GAME          EQU   $19
-MENU_LUIGI_WON_INIT   EQU   $1d
-MENU_LUIGI_LOST_INIT  EQU   $1e
-MENU_LUIGI_WON        EQU   $20
-MENU_LUIGI_LOST       EQU   $21
-
-
+DEF MENU_IN_GAME          EQU   $00
+DEF MENU_GAME_OVER_INIT   EQU   $01
+DEF MENU_GAME_OVER        EQU   $04
+DEF MENU_TYPE_B_WON       EQU   $05
+DEF MENU_TITLE_INIT       EQU   $06
+DEF MENU_TITLE            EQU   $07
+DEF MENU_SELECT_TYPE_INIT EQU   $08
+DEF MENU_IN_GAME_INIT     EQU   $0a
+DEF MENU_SCORE_B          EQU   $0b
+DEF MENU_LOST_ANIM        EQU   $0d
+DEF MENU_SELECT_TYPE      EQU   $0e
+DEF MENU_SELECT_MUSIC     EQU   $0f
+DEF MENU_LEVEL_A_INIT     EQU   $10
+DEF MENU_LEVEL_A          EQU   $11
+DEF MENU_LEVEL_B_INIT     EQU   $12
+DEF MENU_LEVEL_B          EQU   $13
+DEF MENU_HIGH_B           EQU   $14
+DEF MENU_HISCORE          EQU   $15
+DEF MENU_COPYRIGHT_INIT   EQU   $24
+DEF MENU_COPYRIGHT_1      EQU   $25
+DEF MENU_COPYRIGHT_2      EQU   $35
+DEF MENU_ROCKET_1_INIT    EQU   $26
+DEF MENU_ROCKET_1A        EQU   $27
+DEF MENU_ROCKET_1B        EQU   $28
+DEF MENU_ROCKET_1C        EQU   $29
+DEF MENU_ROCKET_1D        EQU   $02
+DEF MENU_ROCKET_1E        EQU   $03
+DEF MENU_ROCKET_1F        EQU   $2C
+DEF MENU_ROCKET_1G        EQU   $2D
+DEF MENU_ROCKET_2_INIT    EQU   $34
+DEF MENU_ROCKET_2A        EQU   $2E
+DEF MENU_ROCKET_2B        EQU   $2F
+DEF MENU_ROCKET_2C        EQU   $30
+DEF MENU_ROCKET_2D        EQU   $31
+DEF MENU_ROCKET_2E        EQU   $32
+DEF MENU_ROCKET_2F        EQU   $33
+DEF MENU_CELEBRATE        EQU   $22
+DEF MENU_VS_INIT          EQU   $16
+DEF MENU_VS_MODE          EQU   $17
+DEF MENU_VS_GAME_INIT     EQU   $18
+DEF MENU_VS_GAME          EQU   $19
+DEF MENU_LUIGI_WON_INIT   EQU   $1d
+DEF MENU_LUIGI_LOST_INIT  EQU   $1e
+DEF MENU_LUIGI_WON        EQU   $20
+DEF MENU_LUIGI_LOST       EQU   $21

--- a/main.asm
+++ b/main.asm
@@ -4,7 +4,7 @@ INCLUDE "palettes.asm"
 ; rst vectors
 SECTION "rst 00", ROM0 [$00]
 	jp Init
-  
+
 SECTION "rst 08", ROM0 [$08]
 	jp Init
 	DS $5
@@ -29,7 +29,7 @@ SECTION "rst 28", ROM0 [$28]
 ; * jumps to that address
 
 	add a, a	; double GAME_STATUS
-	pop hl		
+	pop hl
 	ld e, a
 	ld d, $00
 	add hl, de	; add 2 * GAME_STATUS to caller address
@@ -75,26 +75,26 @@ Serial::
 	pop af
 	reti
 
-; Small switch statement: 
+; Small switch statement:
 ; (rst 28 jumps to following address, depending on current $ff00 + $cd)
 func_006b:
 	ldh a, [$ff00 + $cd]
 	rst $28
-	
+
 	db $78, $00	; => 0078
 	db $9f, $00	; => 009f
 	db $a4, $00	; => 00a4
 	db $ba, $00	; => 00ba
 	db $ea, $27	; => 27ea
-	
+
 l_0078:
 	ldh a, [rGAME_STATUS]
 	cp MENU_TITLE
 	jr z, l_0086
-	
+
 	cp MENU_TITLE_INIT
 	ret z
-	
+
 	ld a, MENU_TITLE_INIT
 	ldh [rGAME_STATUS], a
 	ret
@@ -121,7 +121,7 @@ func_009f:
 	ldh a, [rSB]
 	ldh [$ff00 + $d0], a
 	ret
-	
+
 func_00a4:
 	ldh a, [rSB]
 	ldh [$ff00 + $d0], a
@@ -149,7 +149,7 @@ func_00ba:
 	ld a, $80
 	ldh [rSC], a
 	ret
-	
+
 func_00d0:
 	ldh a, [$ff00 + $cd]
 	cp $02
@@ -164,11 +164,11 @@ func_00d0:
 SECTION "Entry", ROM0 [$100]
   nop
 	jp Start
-  
+
 SECTION "Header", ROM0 [$104]
 	db $ce, $ed, $66, $66, $cc, $0d, $00, $0b, $03, $73, $00, $83, $00, $0c, $00, $0d,
 	db $00, $08, $11, $1f, $88, $89, $00, $0e, $dc, $cc, $6e, $e6, $dd, $dd, $d9, $99,
-	db $bb, $bb, $67, $63, $6e, $0e, $ec, $cc, $dd, $dc, $99, $9f, $bb, $b9, $33, $3e, 
+	db $bb, $bb, $67, $63, $6e, $0e, $ec, $cc, $dd, $dc, $99, $9f, $bb, $b9, $33, $3e,
 	db "TETRIS", $00, $00, $00, $00, $00, $00, $00, $00, $00
 	db $00		;dmg - classic gameboy
 	db $00, $00	;new license
@@ -199,7 +199,7 @@ l_015d:
 	ld a, [hl]
 	and b
 	ret
-	
+
 func_0166:
 	ld a, e
 	add a, [hl]
@@ -223,23 +223,23 @@ func_0166:
 	ret
 
 ; The VBlank interrupt handler, must occur once somewhen during the game-loop
-VBlank::	
+VBlank::
 	push af				; Store registers
 	push bc
 	push de
 	push hl
-	
+
 	ldh a, [rREQUEST_SERIAL_TRANSFER]	; Transfer data only if requested
 	and a
 	jr z, .skip_serial_connection
-	
+
 	ldh a, [$ff00 + $cb]			; ?
 	cp $29
 	jr nz, .skip_serial_connection
-	
+
 	xor a
 	ldh [rREQUEST_SERIAL_TRANSFER], a	; Clear request
-	ldh a, [rSB_DATA]			
+	ldh a, [rSB_DATA]
 	ldh [rSB], a				; Send data to link cable
 	ld hl, rSC
 	ld [hl], $81				; Use internal clock (= this GB is the master)
@@ -309,26 +309,26 @@ Init:
 	jr nz, .loop_0
 	dec c
 	jr nz, .loop_0
-	
+
 Screen_Setup: ; $21B
 
-rINTERRUPT_DEFAULT EQU %00000001
+DEF rINTERRUPT_DEFAULT EQU %00000001
 ; * VBlank interrupt enabled
 ; * everything else disabled
 
-rLCDC_START EQU %10000000
+DEF rLCDC_START EQU %10000000
 ; * LCD enabled
 ; * everything else disabled
 
 	ld a, rINTERRUPT_DEFAULT
-	
+
 	di
-	
+
 	ldh [rIF], a
 	ldh [rIE], a
-	
+
 	xor a
-	
+
 	ldh [rSCY], a
 	ldh [rSCX], a
 	ldh [rUNKNOWN1], a
@@ -342,25 +342,25 @@ rLCDC_START EQU %10000000
 	ldh a, [rLY]
 	cp SCREEN_HEIGHT + 4
 	jr nz, .loop_1
-	
+
 	ld a, $03
 	ldh [rLCDC], a
-	
+
 	ld a, PALETTE_1
 	ldh [rBGP], a
 	ldh [rOBP0], a
-	
+
 	ld a, PALETTE_2
 	ldh [rOBP1], a
 	ld hl, rNR52
-	
+
 	ld a, SOUND_ON
 	ldd [hl], a	; rNR51
-	
+
 	ld a, USE_ALL_CHANNELS
 	ldd [hl], a	; rNR50
 	ld [hl], MASTER_VOLUME_MAX
-	
+
 	ld a, $01
 	ld [rMBC], a
 	ld sp, SP_INIT
@@ -371,9 +371,9 @@ rLCDC_START EQU %10000000
 	ld b, $00
 .loop_2:
 	ldd [hl], a
-	dec b		
+	dec b
 	jr nz, .loop_2	; Flush 256 bytes from end of WRAM Bank 1
-	
+
 ; Flush WRAM Bank 0
 	ld hl, $cfff	; End of WRAM Bank 0
 	ld c, $10	; $1000 = size of WRAM Bank 0
@@ -397,8 +397,8 @@ Flush_VRAM::
 	jr nz, .loop_4
 	dec c
 	jr nz, .loop_4
-	
-; Flush Object Attribute Memory (OAM)	
+
+; Flush Object Attribute Memory (OAM)
 	ld hl, $feff	; End of unusable hardware RAM
 	ld b, $00
 .loop_5:
@@ -413,7 +413,7 @@ Flush_VRAM::
 	ldd [hl], a
 	dec b
 	jr nz, .loop_6	; Flush 128 bytes (Entire HRAM)
-	
+
 ; Copy DMA Transfer routine into HRAM
 	ld c, $b6	; Target location in HRAM
 	ld b, $0c	; Routine length
@@ -424,11 +424,11 @@ Flush_VRAM::
 	inc c
 	dec b
 	jr nz, .loop_7
-	
+
 	call Flush_BG1
 	call Sound_Init
 
-rINTERRUPT_SERIAL EQU %00001001
+DEF rINTERRUPT_SERIAL EQU %00001001
 ; * VBlank interrupt enabled
 ; * Serial interrupt enabled
 ; * everything else disabled
@@ -439,18 +439,18 @@ rINTERRUPT_SERIAL EQU %00001001
 ; Set up a few game variables
 	ld a, GAME_TYPE_A
 	ldh [rGAME_TYPE], a
-	
+
 	ld a, MUSIC_TYPE_A
 	ldh [rMUSIC_TYPE], a
-	
+
 	ld a, MENU_COPYRIGHT_INIT
 	ldh [rGAME_STATUS], a
-	
+
 	ld a, LCDC_ON
 	ldh [rLCDC], a
-	
+
 	ei			; enable interrupts (VBlank interrupt handler can occur now)
-	
+
 	xor a
 	ldh [rIF], a		; clear all interrupt flags
 	ldh [rWY], a		; Set Window X & Y Position to initial
@@ -461,12 +461,12 @@ rINTERRUPT_SERIAL EQU %00001001
 	call Read_Joypad
 	call State_Machine
 	call func_7ff0
-	
+
 	ldh a, [rBUTTON_DOWN]
 	and $0f
-	cp $0f			
+	cp $0f
 	jp z, Screen_Setup	; if all directional keys are pressed, reset game
-	
+
 ; Countdown both $ffa6 and $ffa7 by 1, if >0
 	ld hl, rCOUNTDOWN
 	ld b, $02
@@ -491,7 +491,7 @@ rINTERRUPT_SERIAL EQU %00001001
 	jr z, .wait_for_vblank	; Loop until VBlank handler has finished executing
 	xor a
 	ldh [rVBLANK_DONE], a
-	
+
 	jp .Main_Loop
 
 
@@ -499,7 +499,7 @@ State_Machine::
 	ldh a, [rGAME_STATUS]
 	rst $28
 
-; Big switch statement: 
+; Big switch statement:
 ; (rst $28 jumps to following address, depending on current GAME_STATUS)
 	db $ce, $1b	; MENU_IN_GAME 		=> 1bce
 	db $e2, $1c	; MENU_GAME_OVER_INIT	=> 1ce2
@@ -556,15 +556,15 @@ State_Machine::
 	db $1b, $13	; MENU_ROCKET_2_INIT	=> 131b
 	db $a0, $03	; MENU_COPYRIGHT_2	=> 03a0
 	db $ea, $27	; (unknown)		=> 27ea
- 
- 
+
+
 lbl_MENU_COPYRIGHT_INIT::
 	call WAIT_FOR_VBLANK
 	call COPY_TITLE_TILES
 	ld de, $4a07		; Starting address of copyright screen tile map in ROM
 	call COPY_TILEMAP
 	call CLEAR_OAM_DATA
-	
+
 	ld hl, $c300		; Copy some values into $c300+. Seems to be serial related
 	ld de, $6450
 .loop_12:
@@ -574,8 +574,8 @@ lbl_MENU_COPYRIGHT_INIT::
 	ld a, h
 	cp $c4
 	jr nz, .loop_12
-	
-	ld a, LCDC_STANDARD		
+
+	ld a, LCDC_STANDARD
 	ldh [rLCDC], a
 	ld a, $fa		; ~ 4 seconds
 	ldh [rCOUNTDOWN], a
@@ -593,8 +593,8 @@ lbl_MENU_COPYRIGHT_1::
 	ld a, MENU_COPYRIGHT_2
 	ld [rGAME_STATUS], a
 	ret
-	
-	
+
+
 ; Wait until either previous countdown (4 secs) is done, or anz button was hit, then change game status to MENU_TITLE_INIT
 lbl_MENU_COPYRIGHT_2::
 	ldh a, [rBUTTON_HIT]
@@ -607,7 +607,7 @@ lbl_MENU_COPYRIGHT_2::
 	ld a, MENU_TITLE_INIT
 	ld [rGAME_STATUS], a
 	ret
-	
+
 lbl_MENU_TITLE_INIT::
 	call WAIT_FOR_VBLANK
 	xor a
@@ -651,23 +651,23 @@ l_03e9:
 	ld [hl], $58		; Little arrow tile address
 	ld a, $03
 	ld [$dfe8], a
-	
+
 	ld a, LCDC_STANDARD
 	ldh [rLCDC], a
-	
+
 	ld a, MENU_TITLE
 	ldh [rGAME_STATUS], a
-	
+
 	ld a, $7d		; ~ 2 seconds
 	ldh [rCOUNTDOWN], a
-	
+
 	ld a, $04
 	ldh [rMUSIC_COUNTDOWN], a
-	
+
 	ldh a, [rDEMO_GAME]
 	and a
 	ret nz
-	
+
 	ld a, $13
 	ldh [rMUSIC_COUNTDOWN], a
 	ret
@@ -675,21 +675,21 @@ l_03e9:
 PLAY_DEMO_GAME:
 	ld a, GAME_TYPE_A
 	ldh [rGAME_TYPE], a
-	
+
 	ld a, $09
 	ldh [rLEVEL_A], a		; set to level 9
-	
+
 	xor a
 	ldh [rPLAYERS], a		; 1 player mode
 	ldh [rDEMO_STATUS], a
 	ldh [rDEMO_BUTTON_HIT], a
 	ldh [rDEMO_ACTION_COUNTDOWN], a
-	
+
 	ld a, $62			; $62b0 = start address of first demo storyboard
 	ldh [rDEMO_STORYBOARD_1], a
 	ld a, $b0
 	ldh [rDEMO_STORYBOARD_2], a
-	
+
 	ldh a, [rDEMO_GAME]
 	cp $02
 	ld a, $02
@@ -698,60 +698,60 @@ PLAY_DEMO_GAME:
 ; set up second demo game:
 	ld a, GAME_TYPE_B
 	ldh [rGAME_TYPE], a
-	
+
 	ld a, $09
 	ldh [rLEVEL_B], a		; set to level 9
-	
+
 	ld a, $02
 	ldh [rINITIAL_HEIGHT], a
-	
+
 	ld a, $63			; $63b0 = start address of second demo storyboard
 	ldh [rDEMO_STORYBOARD_1], a
 	ld a, $b0
 	ldh [rDEMO_STORYBOARD_2], a
-	
+
 	ld a, $11
 	ldh [rDEMO_STATUS], a
 	ld a, $01
 
 .set_up_first_demo_game:
 	ldh [rDEMO_GAME], a
-	
+
 	ld a, MENU_IN_GAME_INIT
 	ldh [rGAME_STATUS], a		; start a normal in-game (called routines are mostly the same)
-	
+
 	call WAIT_FOR_VBLANK
 	call COPY_IN_GAME_TILES
-	
+
 	ld de, $4cd7			; start of tile map for game select screen
 	call COPY_TILEMAP		; copy that tile map to VRAM (useless!)
 	call CLEAR_OAM_DATA
-	
+
 	ld a, LCDC_STANDARD
 	ldh [rLCDC], a
 	ret
-	
-	
+
+
 func_0474: 	; not used function
 	ld a, $ff
 	ldh [rUNUSED], a
 	ret
-	
-	
-lbl_MENU_TITLE::	
+
+
+lbl_MENU_TITLE::
 	ldh a, [rCOUNTDOWN]
 	and a
 	jr nz, .skip_still_no_demo
 	ld hl, rMUSIC_COUNTDOWN
 	dec [hl]
 	jr z, PLAY_DEMO_GAME
-	
+
 	ld a, $7d		; ~ 2 seconds
 	ldh [rCOUNTDOWN], a
-	
+
 .skip_still_no_demo:
 	call WASTE_TIME
-	
+
 	ld a, $55		; Something Serial Data related
 	ldh [rSB], a
 	ld a, $80
@@ -759,37 +759,37 @@ lbl_MENU_TITLE::
 	ldh a, [$ff00 + $cc]
 	and a
 	jr z, .skip_title_serial_check
-	
+
 	ldh a, [$ff00 + $cb]
 	and a
 	jr nz, l_04d7
-	
+
 	xor a
 	ldh [$ff00 + $cc], a
 	jr l_0509
-	
+
 .skip_title_serial_check:
 	ldh a, [rBUTTON_HIT]
 	ld b, a
-	
+
 	ldh a, [rPLAYERS]
-	
+
 	bit BTN_SELECT, b
 	jr nz, MENU_TITLE_SELECT_BTN
-	
+
 	bit BTN_RIGHT, b
 	jr nz, MENU_TITLE_RIGHT_BTN
-	
+
 	bit BTN_LEFT, b
 	jr nz, MENU_TITLE_LEFT_BTN
-	
+
 	bit BTN_START, b
 	ret z			; Return if no relevant button was pressed
-	
+
 	and a
 	ld a, $08
 	jr z, first_player_selected	; jump if 1 player selected
-	
+
 	ld a, b
 	cp $08
 	ret nz
@@ -834,7 +834,7 @@ MENU_TITLE_SELECT_BTN:
 	xor $01		; toggles rPLAYERS value (i.e. 0 -> 1 and 1 -> 0)
 l_04f5:
 	ldh [rPLAYERS], a
-	
+
 	and a
 	ld a, $10
 	jr z, .move_arrow_left
@@ -861,14 +861,14 @@ CHECK_DEMO_GAME_FINISHED::
 	ldh a, [rDEMO_GAME]
 	and a
 	ret z			; return if NOT in demo mode
-	
+
 	call WASTE_TIME
-	
+
 	xor a				; empty serial connection byte
 	ldh [rSB], a
 	ld a, $80			; turn on serial connection and act as slave (allow receiving)
-	ldh [rSC], a			
-	
+	ldh [rSC], a
+
 	ldh a, [rBUTTON_HIT]
 	bit BTN_START, a
 	jr z, .dont_cancel_demo_game	; jump if Start button not pressed
@@ -876,8 +876,8 @@ CHECK_DEMO_GAME_FINISHED::
 	ld a, $33			; load byte $33 for starting a serial connection
 	ldh [rSB], a
 	ld a, $81			; turn on serial connection and act as master (try sending)
-	ldh [rSC], a			 
-	
+	ldh [rSC], a
+
 	ld a, MENU_TITLE_INIT		; quit demo game and return to main menu
 	ldh [rGAME_STATUS], a
 	ret
@@ -886,16 +886,16 @@ CHECK_DEMO_GAME_FINISHED::
 	ld hl, rDEMO_STATUS
 	ldh a, [rDEMO_GAME]
 	cp $02				; if is currently running the first demo game, ...
-	
+
 	ld b, $10
 	jr z, .skip_3
-	
+
 	ld b, $1d
 .skip_3:				; ... then set b to $10, otherwise set b to $1d.
-	ld a, [hl]			
-	cp b				
+	ld a, [hl]
+	cp b
 	ret nz				; if rDEMO_STATUS not equal b then keep going, ...
-	
+
 	ld a, MENU_TITLE_INIT		; ... otherwise return to main menu.
 	ldh [rGAME_STATUS], a		; (rDEMO_STATUS increases with each block, game 1 goes from $03 to $09, game 2 from $14 to $1c)
 	ret
@@ -907,15 +907,15 @@ SIMULATE_BUTTON_PRESSES::
 	ldh a, [rDEMO_GAME]
 	and a
 	ret z			; return if NOT in demo mode
-	
+
 	ldh a, [rUNUSED]
 	cp $ff
 	ret z			; always false
-	
+
 	ldh a, [rDEMO_ACTION_COUNTDOWN]
 	and a
 	jr z, .retrieve_next_action	; jump if countdown reached zero
-	
+
 	dec a
 	ldh [rDEMO_ACTION_COUNTDOWN], a ; countdown by 1
 	jr .clear_real_button_press
@@ -926,7 +926,7 @@ SIMULATE_BUTTON_PRESSES::
 	ldh a, [rDEMO_STORYBOARD_2]
 	ld l, a				; load the current storyboard address into hl
 	ldi a, [hl]			; get first value at address -> supposed button press
-	
+
 	ld b, a
 	ldh a, [rDEMO_BUTTON_HIT]
 	xor b
@@ -935,10 +935,10 @@ SIMULATE_BUTTON_PRESSES::
 					; if any button is pressed twice in a row, turn it off now.
 	ld a, b
 	ldh [rDEMO_BUTTON_HIT], a	; (also save it at rDEMO_BUTTON_HIT)
-	
+
 	ldi a, [hl]			; load the button press duration from storyboard
 	ldh [rDEMO_ACTION_COUNTDOWN], a
-	
+
 	ld a, h
 	ldh [rDEMO_STORYBOARD_1], a
 	ld a, l
@@ -948,11 +948,11 @@ SIMULATE_BUTTON_PRESSES::
 .clear_real_button_press:
 	xor a
 	ldh [rBUTTON_HIT], a
-	
+
 .store_actual_button_press:
 	ldh a, [rBUTTON_DOWN]
 	ldh [rDEMO_ACTUAL_BUTTON], a	; store actual button presses into rDEMO_ACTUAL_BUTTON
-	ldh a, [rDEMO_BUTTON_HIT]	
+	ldh a, [rDEMO_BUTTON_HIT]
 	ldh [rBUTTON_DOWN], a		; replace them with the simulated buttons from the demo storyboard
 	ret
 
@@ -967,7 +967,7 @@ USELESS_FUNCTION::
 	ldh a, [rDEMO_GAME]
 	and a
 	ret z				; return if NOT demo mode
-	
+
 	ldh a, [rUNUSED]
 	cp $ff
 	ret nz				; always true - always return
@@ -978,24 +978,24 @@ USELESS_FUNCTION::
 	ldh a, [rDEMO_BUTTON_HIT]
 	cp b
 	jr z, l_05ad
-	
+
 	ldh a, [rDEMO_STORYBOARD_1]
 	ld h, a
 	ldh a, [rDEMO_STORYBOARD_2]
 	ld l, a
-	
+
 	ldh a, [rDEMO_BUTTON_HIT]
 	ldi [hl], a
 	ldh a, [rDEMO_ACTION_COUNTDOWN]
 	ldi [hl], a
-	
+
 	ld a, h
 	ldh [rDEMO_STORYBOARD_1], a
 	ld a, l
 	ldh [rDEMO_STORYBOARD_2], a
 	ld a, b
 	ldh [rDEMO_BUTTON_HIT], a
-	
+
 	xor a
 	ldh [rDEMO_ACTION_COUNTDOWN], a
 	ret
@@ -1010,12 +1010,12 @@ l_05ad:
 RESTORE_BUTTON_PRESSES::
 	ldh a, [rDEMO_GAME]
 	and a
-	ret z				; return if NOT in demo game 
-	
+	ret z				; return if NOT in demo game
+
 	ldh a, [rUNUSED]
 	and a
 	ret nz
-	
+
 	ldh a, [rDEMO_ACTUAL_BUTTON]
 	ldh [rBUTTON_DOWN], a		; restore stored real button presses at begin of menu_in_game function
 	ret
@@ -1050,8 +1050,8 @@ l_05d1:
 	ld a, $2b
 	ldh [rGAME_STATUS], a
 	ret
-	
-	
+
+
 func_05f7:
 	ldh a, [$ff00 + $cb]
 	cp $29
@@ -1215,7 +1215,7 @@ l_06e1:
 	db $40, $28, $AE, $00, $40, $30, $AE, $20, $48, $28, $AF, $00
 	db $48, $30, $AF, $20, $78, $28, $C0, $00, $78, $30, $C0, $20
 	db $80, $28, $C1, $00, $80, $30, $C1, $20
-	
+
 func_0725:
 	ld a, [de]
 	ldi [hl], a
@@ -3051,8 +3051,8 @@ l_1225:
 	ld hl, $9d29
 	call func_19ff
 	ret
-	
-	
+
+
 lbl_MENU_ROCKET_1D::
 	ldh a, [rCOUNTDOWN]
 	and a
@@ -3085,8 +3085,8 @@ lbl_MENU_ROCKET_1D::
 l_1277:
 	call func_13fa
 	ret
-	
-	
+
+
 lbl_MENU_ROCKET_1E::
 	ldh a, [rCOUNTDOWN]
 	and a
@@ -4554,7 +4554,7 @@ l_1afa:
 	ldh [rGRAVITY], a
 	ldh [$ff00 + $9a], a
 	ret
-	
+
 	db $34, $30, $2C, $28, $24, $20, $1B, $15, $10, $0A, $09, $08
 	db $07, $06, $05, $05, $04, $04, $03, $03, $02
 
@@ -4688,15 +4688,15 @@ l_1bc8:
 	cp $2c
 	jr nz, l_1bc2
 	ret
-	
+
 SECTION "MENU_IN_GAME", ROM0 [$1BCE]
 lbl_MENU_IN_GAME::
 	call START_SELECT_HANDLER	; check if start or select was pressed
-	
+
 	ldh a, [rPAUSE_MENU]
 	and a
 	ret nz				; return if in pause menu
-	
+
 	call CHECK_DEMO_GAME_FINISHED
 	call SIMULATE_BUTTON_PRESSES
 	call USELESS_FUNCTION		; does nothing b/c depending on unused variable
@@ -4732,33 +4732,33 @@ START_SELECT_HANDLER::
 	and $0f
 	cp $0f
 	jp z, Screen_Setup		; if buttons A, B, Select and Start are all pressed, reset game
-	
+
 	ldh a, [rDEMO_GAME]
 	and a
 	ret nz				; return now, if it is only a demo game
-	
+
 	ldh a, [rBUTTON_HIT]
 	bit BTN_START, a
 	jr z, toggle_next_block_hidden	; if Start is NOT pressed, check if Select is pressed
-					
+
 					; start button was pressed:
 	ldh a, [rPLAYERS]
 	and a
 	jr nz, l_1c6a			; jump if 2 player mode
-	
+
 	ld hl, rLCDC
-	
+
 	ldh a, [rPAUSE_MENU]
 	xor $01				; toggle start menu flag
 	ldh [rPAUSE_MENU], a
 	jr z, .unpausing			; jump if now unpausing
-					
+
 					; pausing now:
 	set 3, [hl]			; select second background tile map at $9c00 (already contains the pause menu text)
-	
+
 	ld a, $01
 	ld [rPAUSED], a			; set "just paused" flag
-	
+
 	ld hl, $994e			; start of line tiles on BG tile map 1
 	ld de, $9d4e			; start of line tiles on BG tile map 2
 	ld b, $04			; length of line tiles (4 numbers max, 9999 is highest line number)
@@ -4766,19 +4766,19 @@ START_SELECT_HANDLER::
 	ldh a, [rLCDC_STAT]
 	and $03
 	jr nz, .loop_18			; Loop until H-Blank reached (bits 0 and 1 of rLCDC_STAT not set)
-	
+
 	ldi a, [hl]
 	ld [de], a			; Copy score tile from BG tile map 1 to BG tile map 2
 	inc de
 	dec b
 	jr nz, .loop_18			; loop while there are still tiles left (and wait for H-Blank again)
-	
+
 	ld a, $80
 .set_next_block_display:
 	ld [rHIDE_NEXT_BLOCK_DISPLAY], a	; set the actual visibility of the next block display
 .l_1c50:
 	ld [rBLOCK_VISIBILITY], a
-	
+
 	call func_2683
 	call func_2696
 	ret
@@ -4787,11 +4787,11 @@ START_SELECT_HANDLER::
 	res 3, [hl]			; select first background tile map at $9800 (still contains the fallen blocks)
 	ld a, $02
 	ld [rPAUSED], a			; set the "just unpaused" flag
-	
+
 	ld a, [rHIDE_NEXT_BLOCK]
 	and a
 	jr z, .set_next_block_display	; jump if next block was not hidden before pausing
-	
+
 	xor a
 	jr .l_1c50			; jump if next block was hidden before pausing
 
@@ -4879,7 +4879,7 @@ l_1cd3:
 	ld a, [bc]
 	ld e, $1c
 	db $0E
-	
+
 lbl_MENU_GAME_OVER_INIT::
 	ld a, $80
 	ld [rBLOCK_VISIBILITY], a
@@ -4897,8 +4897,8 @@ lbl_MENU_GAME_OVER_INIT::
 	ld a, $0d
 	ldh [rGAME_STATUS], a
 	ret
-	
-	
+
+
 lbl_MENU_GAME_OVER::
 	ldh a, [rBUTTON_HIT]
 	bit 0, a
@@ -4920,8 +4920,8 @@ l_1d0f:
 l_1d23:
 	ldh [rGAME_STATUS], a
 	ret
-	
-	
+
+
 lbl_MENU_TYPE_B_WON::
 	ldh a, [rCOUNTDOWN]
 	and a
@@ -5752,49 +5752,49 @@ clear_row_animation::
 	ldh a, [rBLOCK_STATUS]
 	cp $03
 	ret nz				; Return if not right at end of block placement handling
-	
+
 	ldh a, [rCOUNTDOWN]
 	and a
 	ret nz				; Return if there is a countdown running
-	
+
 	ld de, rLINE_CLEAR_START
 	ldh a, [rCLEAR_PROGRESS]
 	bit 0, a			; Check if lowest bit of rCLEAR_PROGRESS is set
 	jr nz, .unfill_block_rows	; Jump if rCLEAR_PROGRESS = 1,3,5 or 7
-	
+
 	ld a, [de]
 	and a
-	jr z, .nothing_to_clear		; Jump if line is clear	
+	jr z, .nothing_to_clear		; Jump if line is clear
 
 
 
 ; At RAM addresses $c0a3 to $c0aa lie the VRAM starting map addresses for the
 ; to be removed block lines. (The higher byte needs to be reduced by $30 first)
 ; i.e.: The second to last line is to be cleared, the first block on that row has
-; the map address of $9A02. 
+; the map address of $9A02.
 ; It is therefore saved at $c0a3 as $ca02.
 
 .fill_block_rows:
-	sub a, $30		
+	sub a, $30
 	ld h, a				; Get the first block's address' high byte
 	inc de
-	ld a, [de]				
+	ld a, [de]
 	ld l, a				; Get the first block's address' low byte
-	ldh a, [rCLEAR_PROGRESS]	
-	cp $06						
-	ld a, $8c			
+	ldh a, [rCLEAR_PROGRESS]
+	cp $06
+	ld a, $8c
 	jr nz, .dark_blocks		; if the clearing progress is in state 6 (= almost done)
 	ld a, $2f			; fill line with white blocks (tile 2f)
 .dark_blocks:				; otherwise use dark blocks (tile 8c)
-	ld c, $0a			; 10 = width of tetris block line		
-.loop_10:				
+	ld c, $0a			; 10 = width of tetris block line
+.loop_10:
 	ldi [hl], a			; fill whole line of tile map with chosen block
-	dec c				
-	jr nz, .loop_10			
+	dec c
+	jr nz, .loop_10
 	inc de
 	ld a, [de]
 	and a
-	jr nz, .fill_block_rows		; check if another line needs to be cleared, then loop	
+	jr nz, .fill_block_rows		; check if another line needs to be cleared, then loop
 .increase_clear_progress:
 	ldh a, [rCLEAR_PROGRESS]
 	inc a
@@ -5819,8 +5819,8 @@ clear_row_animation::
 
 .unfill_block_rows:
 	ld a, [de]	; ([de] still points to the first block of the first line to be removed)
-	ld h, a		
-	sub a, $30	
+	ld h, a
+	sub a, $30
 	ld c, a		; set bc to the correct RAM location (where all tiles are saved)
 	inc de
 	ld a, [de]
@@ -5835,7 +5835,7 @@ clear_row_animation::
 	inc hl
 	dec b
 	jr nz, .loop_11
-	
+
 	inc de
 	ld a, [de]
 	and a
@@ -6087,9 +6087,9 @@ func_239e:
 
 func_23b7:
 	ldh a, [rROW_UPDATE]
-	cp $12		
+	cp $12
 	ret nz			; Return if not row 12 is to be copied
-	ld hl, $9822		
+	ld hl, $9822
 	ld de, $c822
 	call COPY_ROW
 	ld hl, $986d
@@ -6170,11 +6170,11 @@ func_243b:
 	ldh a, [rGAME_STATUS]
 	and a
 	ret nz		; return if not in-game
-	
+
 	ldh a, [rGAME_TYPE]
 	cp GAME_TYPE_A
 	ret nz		; return if type B game
-	
+
 	ld de, $c0a2
 	call func_2a36
 	ret
@@ -6275,34 +6275,34 @@ func_24bb:
 	ld a, [hl]
 	cp $80
 	ret z				; return if there is no falling block (visible)
-	
+
 	ld l, $03
 	ld a, [hl]			; = rBLOCK_TYPE
 	ldh [$ff00 + $a0], a		; store current block type
-	
+
 	ldh a, [rBUTTON_HIT]
 	ld b, a
-	
+
 	bit BTN_B, b
 	jr nz, .rotate_B_button		; jump if button B was pressed
-	
+
 	bit BTN_A, b
 	jr z, l_2509			; jump if anything BUT button A was pressed
-					
-					; Button A pressed:	
+
+					; Button A pressed:
 	ld a, [hl]
 	and $03
 	jr z, .block_variation_low_end	; jump if block type MOD 4 = 0 (lowest variation of block)
-	
+
 	dec [hl]			; change to lower variation (rotate clockwise)
-	
+
 	jr .rotation_finished
 
 .block_variation_low_end:
 	ld a, [hl]
 	or $03
 	ld [hl], a			; add 3 to the block variation (starting back at the highest variation)
-	
+
 	jr .rotation_finished
 
 .rotate_B_button:
@@ -6310,9 +6310,9 @@ func_24bb:
 	and $03
 	cp $03
 	jr z, .block_variation_high_end	; jump if block type MOD 4 = 3 (highest variation of block)
-	
+
 	inc [hl]			; change to higher variation (rotate counter-clockwise)
-	
+
 	jr .rotation_finished
 
 .block_variation_high_end:
@@ -6323,20 +6323,20 @@ func_24bb:
 .rotation_finished:
 	ld a, $03
 	ld [$dfe0], a
-	
+
 	call func_2683
 	call func_2573
-	
+
 	and a
 	jr z, l_2509
-	
+
 	xor a
 	ld [$dfe0], a
-	
+
 	ld hl, rBLOCK_TYPE
 	ldh a, [$ff00 + $a0]
 	ld [hl], a
-	
+
 	call func_2683
 
 l_2509:
@@ -6382,7 +6382,7 @@ l_253a:
 l_2549:
 	ldh [$ff00 + $aa], a
 	ret
-	
+
 
 l_254c:
 	bit 5, b
@@ -6632,7 +6632,7 @@ func_2683:
 	ldh [rOAM_TILE_ADDRESS_2], a
 	ld a, $c0
 	ldh [rOAM_TILE_ADDRESS_1], a
-	
+
 	ld hl, rBLOCK_VISIBILITY
 	call func_2a89
 	ret
@@ -6709,7 +6709,7 @@ func_2798:
 	ret
 
 
-; copy all tiles as specified in registers de (target), hl (source) and bc (length) 
+; copy all tiles as specified in registers de (target), hl (source) and bc (length)
 COPY_TILES::
 	ldi a, [hl]
 	ld [de], a
@@ -6755,8 +6755,8 @@ COPY_TITLE_TILES::
 	ld bc, $0da0		; length of symbol data set (starting right after characters)
 	call COPY_TILES		; copy all title image tiles (picture of Moscow cathedral)
 	ret
-	
-	
+
+
 	ld bc, $1000
 
 
@@ -6769,11 +6769,11 @@ func_27e4:
 ; Takes a ROM address (de) and copies the full tilemap into Tilemap A (starting at $9800)
 COPY_TILEMAP::
 	ld hl, $9800
-	
+
 ; Allows for a unique tilemap starting address - is only ever used for Tilemap B (starting at $9C00)
 COPY_TILEMAP_B::
 	ld b, $12		; = full 18 rows of tiles
-	
+
 ; Allows for unique tilemap and a custom number of rows (less than the full 18)
 COPY_TILEMAP_FEWER_ROWS::
 	push hl
@@ -6784,7 +6784,7 @@ COPY_TILEMAP_FEWER_ROWS::
 	inc de
 	dec c
 	jr nz, .loop_15
-	
+
 	pop hl
 	push de
 	ld de, $0020
@@ -6824,22 +6824,22 @@ l_281a:
 
 WAIT_FOR_VBLANK::
 	ldh a, [rIE]
-	ldh [rIE_TEMP], a	
-	res 0, a		
+	ldh [rIE_TEMP], a
+	res 0, a
 	ldh [rIE], a		; turn off V-Blank interrupt
 .loop_13:
 	ldh a, [rLY]		; loop until in V-Blank area
 	cp SCREEN_HEIGHT + 1
 	jr nz, .loop_13
-	
+
 	ldh a, [rLCDC]
 	and $7f
 	ldh [rLCDC], a		; turn off LCDC (keep other settings in rLCDC)
-	
+
 	ldh a, [rIE_TEMP]
 	ldh [rIE], a
 	ret
-	
+
 
 	; data section $2839 - $29a5 incl.
 data:
@@ -6885,8 +6885,8 @@ Read_Joypad::
 	cpl		; reverse bits (as pressed buttons are shown as 0's)
 	and $0f		; mask lower nibble
 	swap a		; move it to higher nibble
-	ld b, a		
-	
+	ld b, a
+
 	ld a, 1 << 4 	; select button keys
 	ldh [rJOYP], a
 	rept 10
@@ -6895,7 +6895,7 @@ Read_Joypad::
 	cpl
 	and $0f
 	or b		; In register A: lower nibble = buttons, higher nibble = directional keys
-	
+
 	ld c, a
 	ldh a, [rBUTTON_DOWN]
 	xor c			; XOR+AND gate (only true, if "false -> true",
@@ -6936,7 +6936,7 @@ l_29f6:
 	ld a, l
 	ldh [$ff00 + $b4], a
 	ret
-	
+
 	ldh a, [$ff00 + $b5]
 	ld d, a
 	ldh a, [$ff00 + $b4]
@@ -7030,17 +7030,17 @@ l_2a85:
 	ret
 
 func_2a89:
-	ld a, h			
+	ld a, h
 	ldh [rSPRITE_ORIGINAL_ADDRESS_1], a
 	ld a, l
 	ldh [rSPRITE_ORIGINAL_ADDRESS_2], a
 	ld a, [hl]
 	and a
 	jr z, l_2ab0		; jmp if sprite is (supposed to be) visible
-	
+
 	cp $80
 	jr z, l_2aae		; jmp if sprite is (supposed to be) invisible
-	
+
 l_2a97:
 	ldh a, [rSPRITE_ORIGINAL_ADDRESS_1]
 	ld h, a
@@ -7071,24 +7071,24 @@ l_2ab5:
 	inc de
 	dec b
 	jr nz, l_2ab5
-	
+
 	ldh a, [rOAM_TILE_NO]	; = sprite index (block type)
 	ld hl, $2b64		; list of addresses
-	rlca			
+	rlca
 	ld e, a
 	ld d, $00
 	add hl, de		; add sprite index * 2 to $2b64
 	ld e, [hl]
 	inc hl
 	ld d, [hl]		; retrieve a memory address dependent on current sprite index (smallest is $2c20)
-	ld a, [de]		
+	ld a, [de]
 	ld l, a
 	inc de
 	ld a, [de]
 	ld h, a			; retrieve a new memory address at the previously retrieved address (smallest is $2d58)
 	inc de
 	ld a, [de]
-	ldh [$ff00 + $90], a	
+	ldh [$ff00 + $90], a
 	inc de
 	ld a, [de]
 	ldh [$ff00 + $91], a	; store also two further values in each $ff00 + $90 and $ff00 + $91
@@ -7100,21 +7100,21 @@ read_next_design_element:
 	inc hl			; retrieve the sprite design of the sprite index, using tile numbers, $fe for nothing and $ff for end of block
 	ldh a, [$ff00 + $8c]	; ?
 	ldh [$ff00 + $94], a
-	
+
 	ld a, [hl]
 	cp $ff
-	jr z, l_2aa9		; jump if end of this sprite's design found 
-	
+	jr z, l_2aa9		; jump if end of this sprite's design found
+
 	cp $fd			; (there is $fd during congratulation animation.)
 	jr nz, l_2af4		; jump if not $fd
-	
+
 	ldh a, [$ff00 + $8c]
 	xor $20
 	ldh [$ff00 + $94], a
-	
+
 	inc hl
 	ld a, [hl]		; read input byte after the $fd
-	
+
 	jr l_2af8
 
 is_empty_design_element:
@@ -7135,7 +7135,7 @@ l_2af8:
 	ldh a, [$ff00 + $8b]
 	bit 6, a
 	jr nz, l_2b0b
-	
+
 	ldh a, [$ff00 + $90]
 	add a, b
 	adc a, c
@@ -7187,7 +7187,7 @@ l_2b34:
 	ldh a, [rOAM_VISIBLE]
 	and a
 	jr z, l_2b46			; jump if sprite is (supposed to be) visible
-	
+
 	ld a, $ff
 	jr l_2b48
 
@@ -7195,18 +7195,18 @@ l_2b46:
 	ldh a, [rOAM_Y_POS]
 
 l_2b48:
-	ldi [hl], a		
-	ldh a, [rOAM_X_POS]		
-	ldi [hl], a			
+	ldi [hl], a
+	ldh a, [rOAM_X_POS]
+	ldi [hl], a
 	ldh a, [rOAM_TILE_NO]
 	ldi [hl], a
-	ldh a, [$ff00 + $94]		; 
-	ld b, a				; 
-	ldh a, [$ff00 + $8b]		; 
-	or b				; 
-	ld b, a				; 
-	ldh a, [rOAM_ATTRIBUTE_NO]		; 
-	or b				; "or" both 8b and 9f into the attribute 
+	ldh a, [$ff00 + $94]		;
+	ld b, a				;
+	ldh a, [$ff00 + $8b]		;
+	or b				;
+	ld b, a				;
+	ldh a, [rOAM_ATTRIBUTE_NO]		;
+	or b				; "or" both 8b and 9f into the attribute
 	ldi [hl], a
 	ld a, h
 	ldh [rOAM_TILE_ADDRESS_1], a
@@ -7214,7 +7214,7 @@ l_2b48:
 	ldh [rOAM_TILE_ADDRESS_2], a
 	pop hl
 	jp read_next_design_element
-	
+
 ; start of data section (see above): starting at $2b64
 SECTION "Data", ROM0 [$2B64]
 	db $20, $2C, $24, $2C, $28, $2C, $2C, $2C, $30, $2C, $34, $2C
@@ -7712,7 +7712,7 @@ SECTION "Data2", romx
 	db $46, $46, $46, $46, $4E, $3C, $00, $00, $46, $46, $46, $46
 	db $2C, $18, $00, $00, $46, $46, $56, $7E, $6E, $46, $00, $00
 	db $46, $2C, $18, $38, $64, $42, $00, $00, $66, $66, $3C, $18
-	db $18, $18, $00, $00, $7E, $0E, $1C, $38, $70, $7E, $00, $00	
+	db $18, $18, $00, $00, $7E, $0E, $1C, $38, $70, $7E, $00, $00
 	db $00, $00, $00, $00, $60, $60, $00, $00, $00, $00, $3C, $3C
 	db $00, $00, $00, $00, $00, $22, $14, $08, $14, $22, $00, $00
 	db $00, $36, $36, $5F, $49, $5F, $41, $7F, $41, $3E, $22, $1C
@@ -9034,5 +9034,5 @@ func_7ff0:
 
 Sound_Init::
 	jp $69a5
-	
+
 	db $00, $00, $00, $00, $00, $00, $00, $00, $00

--- a/palettes.asm
+++ b/palettes.asm
@@ -1,2 +1,2 @@
-PALETTE_1  EQU %11100100   ;00 = white, 01 = light grey, 10 = dark grey, 11 = black (read RTL)
-PALETTE_2  EQU %11000100   ;white, light grey, white, black
+DEF PALETTE_1  EQU %11100100   ;00 = white, 01 = light grey, 10 = dark grey, 11 = black (read RTL)
+DEF PALETTE_2  EQU %11000100   ;white, light grey, white, black


### PR DESCRIPTION
rgbds 0.7.0 outputs many deprecation warnings:

	warning: main.asm(1) -> constants.asm(2): [-Wobsolete]
    		`SP_INIT EQU` is deprecated; use `DEF SP_INIT EQU`

This commit removes also all trailing whitespaces